### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Three classifiers, all ONNX-backed, all offline out of the box:
 | **EAT question-type** | 7 main / 53 fine-grained answer categories | EN | bundled |
 | **Yes/No polarity** | yes / no / maybe (for statement answers) | 43 languages | multilingual bundled |
 
-No internet required on first use — English models ship inside the package.
-Other language models download automatically from HuggingFace on first use.
+The package needs no internet connection on first use. English models ship inside the package. Other language models download automatically from HuggingFace on first use.
 
 ---
 
@@ -25,7 +24,6 @@ pip install little-questions
 
 ```python
 from little_questions import Sentence
-
 s = Sentence("Who invented the telephone?")
 print(type(s).__name__)       # Question
 print(s.sentence_type)        # question
@@ -40,20 +38,15 @@ print(f"{s.confidence:.2f}")  # 0.94
 
 ```python
 from little_questions import Sentence, Question, Statement, Command, Request, Exclamation
-
 s = Sentence("Who invented the telephone?")
 assert isinstance(s, Question)
-
 s = Sentence("Open the pod bay doors.")
 assert isinstance(s, Command)
-
 s = Sentence("Could you pass the salt?")
 assert isinstance(s, Request)
 assert isinstance(s, Command)   # Request subclasses Command
-
 s = Sentence("The sky is blue.")
 assert isinstance(s, Statement)
-
 s = Sentence("What a beautiful day!")
 assert isinstance(s, Exclamation)
 ```
@@ -70,7 +63,6 @@ Six classes: `wh_question`, `polar_question`, `statement`, `command`, `request`,
 s = Sentence("Is the Earth flat?")
 print(s.sentence_type)  # polar_question
 print(s.is_question)    # True
-
 s = Sentence("What is the capital of France?")
 print(s.sentence_type)  # wh_question
 print(s.is_question)    # True
@@ -110,7 +102,6 @@ Two-stage inference (eat7 gates eat53) achieves **93.4% macro F1**.
 s = Sentence("When did World War II end?")
 print(s.classification)          # NUM:date
 print(s.confidence)              # 0.97
-
 # Full probability distribution over all 53 labels:
 top3 = sorted(s.classification_scores.items(), key=lambda x: -x[1])[:3]
 print(top3)  # [('NUM:date', 0.97), ('NUM:period', 0.01), ...]
@@ -129,21 +120,17 @@ print(s.classification)   # HUM:ind
 
 ## Yes/No answer polarity
 
-Detect whether a statement is an affirmative, negative, or uncertain answer.
-Works for 43 languages. The multilingual model ships bundled in the package.
+Detect whether a statement is an affirmative, negative, or uncertain answer. Works for 43 languages. The multilingual model ships bundled in the package.
 
 ```python
 from little_questions import Sentence, Statement
-
 a = Sentence("Yes, they can perceive some colors.")
 assert isinstance(a, Statement)
 print(a.answer_polarity)   # yes
 print(a.is_affirmative)    # True
-
 a = Sentence("No, dogs are colorblind.")
 print(a.answer_polarity)   # no
 print(a.is_negative)       # True
-
 a = Sentence("It depends on the breed.")
 print(a.answer_polarity)   # maybe
 ```
@@ -160,7 +147,6 @@ The `answer_polarity` property is lazy-loaded on first access.
 ```python
 s = Sentence("Qui a invente le telephone?", lang="fr")
 print(s.sentence_type)    # question
-
 a = Sentence("Oui, bien sur.", lang="fr")
 print(a.answer_polarity)  # yes
 ```
@@ -177,7 +163,6 @@ sentences = [
     "It is raining outside.",
     "How wonderful!",
 ]
-
 for text in sentences:
     s = Sentence(text)
     if s.is_question:
@@ -226,15 +211,12 @@ pip install little-questions[hf]
 
 ```bash
 pip install little-questions[train]
-
 python -m train.train_eat                 # EAT question classifiers (EN)
 python -m train.train_yesno               # yes/no polarity (43 langs + multilingual)
 python -m train.train_sentence_type       # sentence-type classifiers
-
 python -m train.benchmark_eat
 python -m train.benchmark_sentence_type
 python -m train.benchmark_yesno
-
 python -m train.push_to_hf               # push all models to HuggingFace
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # API Reference
 
-## `little_questions` — top-level package
+## `little_questions` (top-level package)
 
 ### `Sentence`
 
@@ -8,9 +8,7 @@
 class Sentence(str)
 ```
 
-A classified sentence. Subclasses `str`, so all string operations work normally.
-The concrete subclass (`Question`, `Statement`, `Command`, `Request`, `Exclamation`)
-is chosen automatically at construction time.
+A classified sentence. Subclasses `str`, so all string operations work normally. The concrete subclass (`Question`, `Statement`, `Command`, `Request`, `Exclamation`) is chosen automatically at construction time.
 
 **Construction:**
 
@@ -18,8 +16,7 @@ is chosen automatically at construction time.
 Sentence(content: str, lang: str = "en") -> Sentence
 ```
 
-Returns a concrete subclass. Raises `RuntimeError` if no ONNX model is available
-for the requested language.
+Returns a concrete subclass. Raises `RuntimeError` if no ONNX model is available for the requested language.
 
 **Class method:**
 
@@ -61,18 +58,16 @@ All subclass `Sentence` (and `str`).
 | Class | `sentence_type` | Notes |
 |-------|----------------|-------|
 | `Question` | `question` | |
-| `Statement` | `statement` | Adds `answer_polarity` — see below |
+| `Statement` | `statement` | Adds `answer_polarity`, see below |
 | `Command` | `command` | |
-| `Request` | `request` | Subclass of `Command`; also satisfies `is_command` |
+| `Request` | `request` | Subclass of `Command`. Also satisfies `is_command` |
 | `Exclamation` | `exclamation` | |
 
 ---
 
-### `Statement` — answer polarity
+### `Statement`: answer polarity
 
-`Statement` adds three lazy-loaded properties for classifying yes/no responses.
-The yes/no ONNX model is downloaded on first access; a `RuntimeError` is raised
-if no model is available.
+`Statement` adds three lazy-loaded properties for classifying yes/no responses. The yes/no ONNX model downloads on first access. A `RuntimeError` is raised if no model is available.
 
 | Property | Type | Description |
 |----------|------|-------------|
@@ -113,9 +108,7 @@ Return the `YesNoClassifier` singleton for *lang*.
 
 ### `EatClassifier`
 
-Two-stage calibrated EAT classifier. Stage 1 (`eat7_svm_cal`) predicts the main
-category; Stage 2 (`eat53_svm_cal`) scores all 53 labels and renormalises within
-the predicted main category.
+Two-stage calibrated EAT classifier. Stage 1 (`eat7_svm_cal`) predicts the main category. Stage 2 (`eat53_svm_cal`) scores all 53 labels and renormalises within the predicted main category.
 
 ```python
 EatClassifier.get_instance(lang: str) -> EatClassifier
@@ -143,8 +136,7 @@ SentenceTypeClassifier.get_instance(lang: str) -> SentenceTypeClassifier
 | `predict` | `(text: str) -> str` | Sentence type: `question`/`statement`/`command`/`request`/`exclamation` |
 | `score` | `(text: str) -> dict[str, float]` | Softmax probabilities over sentence types |
 
-Supported languages for ONNX inference: `en`, `de`, `es`, `fr`, `it`, `nl`, `pt`.
-Raises `RuntimeError` for unsupported languages.
+Supported languages for ONNX inference: `en`, `de`, `es`, `fr`, `it`, `nl`, `pt`. Raises `RuntimeError` for unsupported languages.
 
 ---
 
@@ -161,8 +153,7 @@ YesNoClassifier.get_instance(lang: str) -> YesNoClassifier
 | `predict` | `(text: str) -> str` | `"yes"`, `"no"`, or `"maybe"` |
 | `score` | `(text: str) -> dict[str, float]` | Calibrated probabilities over `yes`/`no`/`maybe` |
 
-Tries a language-specific model first, then falls back to the multilingual model.
-Raises `RuntimeError` if neither is available.
+Tries a language-specific model first, then falls back to the multilingual model. Raises `RuntimeError` if neither is available.
 
 ---
 
@@ -170,7 +161,6 @@ Raises `RuntimeError` if neither is available.
 
 ```python
 from little_questions.classifiers import clear_classifier_cache, list_supported_languages
-
 clear_classifier_cache()        # force reload on next use
 list_supported_languages()      # languages with a sentence-type ONNX model
 ```
@@ -201,10 +191,12 @@ from little_questions.models import (
 )
 ```
 
-Each function downloads the model from HuggingFace on first call and returns
-the local cache path. Returns `None` if the download fails.
+Each function downloads the model from HuggingFace on first call and returns the local cache path. Returns `None` if the download fails.
 
 HuggingFace repos:
 - EAT models: `TigreGotico/eat-classifiers`
 - Sentence-type models: `TigreGotico/sentence-types`
 - Yes/no models: `TigreGotico/yes-no-classifiers`
+
+---
+[Home](index.md) · [Models →](models.md)

--- a/docs/classification.md
+++ b/docs/classification.md
@@ -1,7 +1,6 @@
 # Classification Benchmarks
 
-All EAT benchmarks use a 15% held-out stratified test split (`random_state=42`).
-Sentence-type and yes/no benchmarks are evaluated on the full labelled datasets.
+All EAT benchmarks use a 15% held-out stratified test split (`random_state=42`). Sentence-type and yes/no benchmarks are evaluated on the full labelled datasets.
 
 ## EAT question-type classification (EN)
 
@@ -48,11 +47,10 @@ Plots saved to `train/reports/sentence_type/`.
 
 | Model | Coverage | Accuracy | Macro F1 |
 |-------|----------|----------|----------|
-| `yesno_svm_cal_{LANG}` (per-language) | 43 languages | ~91–96% | ~91–96% |
+| `yesno_svm_cal_{LANG}` (per-language) | 43 languages | ~91-96% | ~91-96% |
 | `yesno_svm_cal_multilingual` (bundled) | all languages | 84.6% | 84.0% |
 
-The bundled multilingual model is used when no language-specific model is available.
-Per-language models achieve 90–96% macro F1 on their own language.
+The bundled multilingual model is used when no language-specific model is available. Per-language models achieve 90-96% macro F1 on their own language.
 
 Plots saved to `train/reports/yesno/`.
 
@@ -60,8 +58,10 @@ Plots saved to `train/reports/yesno/`.
 
 ```bash
 pip install little-questions[train]
-
 python -m train.benchmark_eat
 python -m train.benchmark_sentence_type
 python -m train.benchmark_yesno
 ```
+
+---
+[← Models](models.md) · [Home](index.md) · [Contributing →](contributing.md)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -13,7 +13,6 @@ pip install -e ".[train]"
 ```bash
 # Unit tests (no models required)
 pytest test/
-
 # Integration tests (require downloaded ONNX models)
 pytest test/ --integration
 ```
@@ -26,8 +25,7 @@ little_questions/
 ├── classifiers.py   # EatClassifier, SentenceTypeClassifier, YesNoClassifier, _OnnxModel
 ├── constants.py     # EAT_LABELS_7, EAT_LABELS_53, SENTENCE_TYPES, MAIN_LABEL_NAMES, SEC_LABEL_NAMES
 └── models.py        # HF auto-download helpers
-
-train/               # Training-only — install with pip install little-questions[train]
+train/               # Training only. Install with pip install little-questions[train]
 ├── classifiers.py       # CalibratedLinearSVCClassifier, LinearSVCClassifier, LogRegClassifier,
 │                        # SGDClassifier, Model2VecClassifier, EATTextPreprocessor
 ├── load_eat.py          # EAT dataset loader (HF + local TSV)
@@ -47,31 +45,33 @@ train/               # Training-only — install with pip install little-questio
 ```bash
 # EAT classifiers (calibrated ONNX, both punctuated + ASR variants)
 python -m train.train_eat
-
 # EAT Model2Vec variants
 python -m train.train_eat_m2v
-
 # Yes/no polarity classifiers (per-language + multilingual)
 python -m train.train_yesno
-
 # Sentence-type classifiers
 python -m train.train_sentence_type
-
 # Benchmarks + plots
 python -m train.benchmark_eat
 python -m train.train_yesno --plot
-
 # Push all models to HuggingFace
 python -m train.push_to_hf
 ```
 
 ## HuggingFace repos
 
+Model repos:
+
 | Repo | Contents |
 |------|----------|
 | `TigreGotico/eat-classifiers` | EAT ONNX models + benchmarks |
 | `TigreGotico/sentence-types` | Sentence-type ONNX models |
 | `TigreGotico/yes-no-classifiers` | Yes/no ONNX models |
+
+Training data repos:
+
+| Repo | Contents |
+|------|----------|
 | `TigreGotico/EAT` | EAT training dataset (30K EN, 53 labels) |
 | `TigreGotico/sentence-types-multilingual` | Sentence-type training data (80K) |
 | `TigreGotico/yes-no-multilingual` | Yes/no training data (8.6K, 43 languages) |
@@ -86,3 +86,6 @@ python -m train.push_to_hf
 | `test:` | Tests only |
 | `refactor:` | Refactor without behaviour change |
 | `chore:` | Build, tooling, dependencies |
+
+---
+[← Classification](classification.md) · [Home](index.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,6 @@
 # little_questions
 
-Classify sentences by **type** (question, command, statement, exclamation, request)
-and, for questions, by **expected answer category** (EAT taxonomy: 7 main, 53 fine-grained).
+Classify sentences by **type** (question, command, statement, exclamation, request) and, for questions, by **expected answer category** (EAT taxonomy: 7 main, 53 fine-grained).
 
 Both classifiers download their ONNX models automatically from HuggingFace on first use.
 
@@ -9,7 +8,6 @@ Both classifiers download their ONNX models automatically from HuggingFace on fi
 
 ```python
 from little_questions import Sentence
-
 # A question
 s = Sentence("Who invented the telephone?")
 print(type(s).__name__)          # Question
@@ -19,12 +17,10 @@ print(s.main_label)              # HUM
 print(s.secondary_label)         # ind
 print(s.pretty_label)            # individual (Human)
 print(s.confidence)              # 0.94
-
 # A command
 s = Sentence("Play some jazz music.")
 print(type(s).__name__)          # Command
 print(s.sentence_type)           # command
-
 # A statement
 s = Sentence("The sky is blue.")
 print(type(s).__name__)          # Statement
@@ -63,8 +59,7 @@ little_questions/
 ├── classifiers.py   # EatClassifier, SentenceTypeClassifier, YesNoClassifier, _OnnxModel
 ├── constants.py     # EAT_LABELS_7, EAT_LABELS_53, SENTENCE_TYPES, MAIN_LABEL_NAMES, SEC_LABEL_NAMES
 └── models.py        # HF auto-download helpers
-
-train/               # Training-only — install with pip install little-questions[train]
+train/               # Training only. Install with pip install little-questions[train]
 ├── classifiers.py       # CalibratedLinearSVCClassifier, LinearSVCClassifier, LogRegClassifier, SGDClassifier, Model2VecClassifier
 ├── load_eat.py          # EAT dataset loader
 ├── load_yesno.py        # Yes/no dataset loader
@@ -80,7 +75,7 @@ train/               # Training-only — install with pip install little-questio
 
 ## Further reading
 
-- [api.md](api.md) — full API reference
-- [models.md](models.md) — model files, HuggingFace repos, training
-- [classification.md](classification.md) — benchmark results
-- [contributing.md](contributing.md) — development setup
+- [api.md](api.md): full API reference
+- [models.md](models.md): model files, HuggingFace repos, training
+- [classification.md](classification.md): benchmark results
+- [contributing.md](contributing.md): development setup

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,29 +1,22 @@
 # Models
 
-All models are LinearSVC classifiers exported to ONNX via skl2onnx.
-Inference requires only `onnxruntime` — no sklearn at runtime.
-Models are downloaded on first use from HuggingFace and cached in
-`~/.local/share/little_questions/`.
+All models are LinearSVC classifiers exported to ONNX via skl2onnx. Inference requires only `onnxruntime`. It needs no sklearn at runtime. Models are downloaded on first use from HuggingFace and cached in `~/.local/share/little_questions/`.
 
-## EAT classifiers — `TigreGotico/eat-classifiers`
+## EAT classifiers (`TigreGotico/eat-classifiers`)
 
 | Model file | Size | Accuracy | Notes |
 |------------|------|----------|-------|
 | `eat53_svm_cal_EN_0.9.0.onnx` | 16 MB | 91.0% macro F1 (53-class) | Calibrated probabilities |
 | `eat7_svm_cal_EN_0.9.0.onnx` | 2.6 MB | 95.6% macro F1 (7-class) | Calibrated probabilities |
 | **Two-stage default** | 18.6 MB total | **93.4%** macro F1 (53-class) | eat7 gates eat53 |
-| `eat53_svm_cal_asr_EN_0.9.0.onnx` | 16 MB | — | Unpunctuated/ASR variant |
-| `eat7_svm_cal_asr_EN_0.9.0.onnx` | 2.6 MB | — | Unpunctuated/ASR variant |
+| `eat53_svm_cal_asr_EN_0.9.0.onnx` | 16 MB | n/a | Unpunctuated/ASR variant |
+| `eat7_svm_cal_asr_EN_0.9.0.onnx` | 2.6 MB | n/a | Unpunctuated/ASR variant |
 
-The default runtime uses the two-stage approach: eat7 predicts the main category,
-then eat53 scores all 53 labels and renormalises within that category.
+The default runtime uses the two-stage approach: eat7 predicts the main category, then eat53 scores all 53 labels and renormalises within that category.
 
 ### Categorical features
 
-The svm_cal models are trained with high-precision lexical signal tokens prepended
-to the question text before TF-IDF vectorization. The tokens are injected at
-inference time by `_eat_preprocess()` in `classifiers.py` — no custom ONNX op
-is needed. Token precision on the EAT corpus:
+The svm_cal models are trained with high-precision lexical signal tokens prepended to the question text before TF-IDF vectorization. The tokens are injected at inference time by `_eat_preprocess()` in `classifiers.py`. No custom ONNX op is needed. Token precision on the EAT corpus:
 
 | Token | Signal | Precision |
 |-------|--------|-----------|
@@ -35,7 +28,7 @@ is needed. Token precision on the EAT corpus:
 | `__feat_howmany__` | NUM | ~90% (how + quantifier word) |
 | `__feat_define__` | DESC | 100% |
 
-## Sentence-type classifiers — `TigreGotico/sentence-types`
+## Sentence-type classifiers (`TigreGotico/sentence-types`)
 
 | Model file | Language |
 |------------|----------|
@@ -47,38 +40,30 @@ is needed. Token precision on the EAT corpus:
 | `sentence_type_NL_0.8.0.onnx` | Dutch |
 | `sentence_type_PT_0.8.0.onnx` | Portuguese |
 
-## Yes/no classifiers — `TigreGotico/yes-no-classifiers`
+## Yes/no classifiers (`TigreGotico/yes-no-classifiers`)
 
 | Model file | Coverage |
 |------------|----------|
 | `yesno_svm_cal_{LANG}_0.9.0.onnx` | Language-specific (43 languages) |
 | `yesno_svm_cal_multilingual_0.9.0.onnx` | All 43 languages combined |
 
-The runtime tries the language-specific model first, then falls back to the
-multilingual model. Character n-gram TF-IDF (2–4) is used — language-agnostic
-and effective for the shallow lexical patterns in yes/no responses.
+The runtime tries the language-specific model first, then falls back to the multilingual model. Character n-gram TF-IDF (2-4) is used. This is language-agnostic and effective for the shallow lexical patterns in yes/no responses.
 
 ## Training
 
 ```bash
 pip install little-questions[train]
-
 # EAT classifiers (ONNX baselines)
 python -m train.train_eat                    # all baselines, 53-class + 7-class
 python -m train.train_eat --model svm_cal    # calibrated SVM only
-
 # EAT Model2Vec variants (12 models)
 python -m train.train_eat_m2v
-
 # Yes/no polarity classifiers
 python -m train.train_yesno                  # all languages + multilingual
-
 # Sentence-type classifiers
 python -m train.train_sentence_type
-
 # Full EAT benchmark + plots
 python -m train.benchmark_eat
-
 # Push to HuggingFace
 python -m train.push_to_hf
 ```
@@ -87,3 +72,6 @@ Training data:
 - EAT: `TigreGotico/EAT` (30K EN questions, 53 labels)
 - Sentence types: `TigreGotico/sentence-types-multilingual` (80K multilingual)
 - Yes/no: `TigreGotico/yes-no-multilingual` (8.6K, 43 languages)
+
+---
+[← API](api.md) · [Home](index.md) · [Classification →](classification.md)


### PR DESCRIPTION
Rewrites README.md and docs/*.md prose for clarity, removing filler and tightening sentence structure. Adds a relative-link navigation footer to each docs/ page (index.md exempt). No facts, code examples, benchmarks, or license text changed.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified first-use behavior, including bundled English models and automatic downloads for other languages.
  * Improved Quick Start examples and formatting for sentence classification and answer polarity.
  * Updated API, classification, model, and contribution guides for clearer navigation and consistent formatting.
  * Clarified testing, training, benchmark, and Hugging Face workflow instructions.
  * Added or refreshed navigation links across documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->